### PR TITLE
Fix runtime crash in Xcode 10

### DIFF
--- a/Sources/MustacheBox.swift
+++ b/Sources/MustacheBox.swift
@@ -133,7 +133,11 @@ final public class MustacheBox : NSObject {
     // MARK: - Other facets
     
     /// See the documentation of `RenderFunction`.
-    public fileprivate(set) var render: RenderFunction
+    fileprivate var renderImpl: RenderFunction
+
+    public func render(_ info: RenderingInfo) throws -> Rendering {
+        return try self.renderImpl(info)
+    }
     
     /// See the documentation of `FilterFunction`.
     public let filter: FilterFunction?
@@ -143,8 +147,8 @@ final public class MustacheBox : NSObject {
     
     /// See the documentation of `DidRenderFunction`.
     public let didRender: DidRenderFunction?
-    
-    
+
+
     // -------------------------------------------------------------------------
     // MARK: - Multi-facetted Box Initialization
     
@@ -435,7 +439,7 @@ final public class MustacheBox : NSObject {
         self.didRender = didRender
         if let render = render {
             self.hasCustomRenderFunction = true
-            self.render = render
+            self.renderImpl = render
             super.init()
         } else {
             // The default render function: it renders {{variable}} tags as the
@@ -447,10 +451,10 @@ final public class MustacheBox : NSObject {
             // We have to set self.render twice in order to avoid the compiler
             // error: "variable 'self.render' captured by a closure before being
             // initialized"
-            self.render = { (_) in return Rendering("") }
+            self.renderImpl = { (_) in return Rendering("") }
             self.hasCustomRenderFunction = false
             super.init()
-            self.render = { [unowned self] (info: RenderingInfo) in
+            self.renderImpl = { [unowned self] (info: RenderingInfo) in
                 
                 // Default rendering depends on the tag type:
                 switch info.tag.type {


### PR DESCRIPTION
`try MustacheBox(message: "1").render("2")` looks like initializing an object and calling a method on it, but it’s really initializing an object and calling a closure property on it.

Since there’s no other strong reference to the `MustacheBox`, it’s deallocated immediately in Xcode 10; since the closure property `render` captures an unowned reference to the `MustacheBox`, a runtime error occurs when the closure is called in this way; since Mustache internally calls the closure in this way, a runtime crash occurs when generating a Mustache template.

This PR avoids the issue by changing `MustacheBox.render` from a closure to a method.